### PR TITLE
GitHub Pages-deploy + CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set version
         id: version
         run: |
-          VERSION=$(date +'%Y.%m.%d').${{ github.run_number }}
+          VERSION=$(date +'%Y.%m').${{ github.run_number }}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 


### PR DESCRIPTION
**Ändringar:**
- GitHub Actions-deploy () — bygger, versioner (YYYY.MM.RUN_NUMBER), skapar tag + release, deployar till GH Pages
- CI () — test + build på PR mot main
- Nedgraderade @angular-builders/jest → 20.0.0 för Angular 20-kompatibilitet
- Versionformat utan dag (YYYY.MM.RUN_NUMBER)
- Uppdaterad AGENTS.md med deploy-dokumentation
-  borttaget (hanteras av CI)

**Fungerar:** testat och verifierat på main ✅